### PR TITLE
(feat): try anndata + dask

### DIFF
--- a/figure_2_iteration_benchmark.py
+++ b/figure_2_iteration_benchmark.py
@@ -18,8 +18,12 @@ import pyarrow.dataset
 import pyarrow.parquet
 import tiledbsoma as soma
 import zarr
-from anndata._core.sparse_dataset import sparse_dataset
+import anndata as ad
+from dask.distributed import Client, LocalCluster
+import os
 
+cluster = LocalCluster(n_workers=os.cpu_count())
+client = Client(cluster)
 
 BATCH_SIZE = 128
 ln.settings.transform.stem_uid = "r9vQub7PWucj"
@@ -85,7 +89,7 @@ class Soma:
 class H5py:
     def __init__(self, path, sparse: bool = False):
         self.file = h5py.File(path, mode="r")
-        self.dataset = sparse_dataset(self.file["X"]) if sparse else self.file["X"]
+        self.dataset = ad.experimental.read_elem_as_dask(self.file["X"]) if sparse else self.file["X"]
         self.labels = self.file["obs"]["cell_states"]["codes"]
 
     def iterate(self, random: bool = False):
@@ -95,7 +99,7 @@ class H5py:
 class Zarr:
     def __init__(self, path, sparse: bool = False):
         self.file = zarr.open(path)
-        self.dataset = sparse_dataset(self.file["X"]) if sparse else self.file["X"]
+        self.dataset = ad.experimental.read_elem_as_dask(self.file["X"]) if sparse else self.file["X"]
         self.labels = self.file["obs"]["cell_states"]["codes"]
 
     def iterate(self, random: bool = False):

--- a/figure_2_iteration_benchmark.py
+++ b/figure_2_iteration_benchmark.py
@@ -20,9 +20,8 @@ import tiledbsoma as soma
 import zarr
 import anndata as ad
 from dask.distributed import Client, LocalCluster
-import os
 
-cluster = LocalCluster(n_workers=os.cpu_count())
+cluster = LocalCluster()
 client = Client(cluster)
 
 BATCH_SIZE = 128


### PR DESCRIPTION
This would be great to try out.  Blocked right now by the upper bound on `anndata` from `lamin`.   See: https://anndata.readthedocs.io/en/latest/generated/anndata.experimental.read_elem_as_dask.html for what I've added here.  To get the needed version of `anndata` + cluster management from `dask`, run `pip install --pre anndata[dask] dask[distributed]`

Would be great to see the results!