### PR TITLE
✨ Made number of shards to use for benchmark configurable

### DIFF
--- a/src/arrayloader_benchmarks/arrayloaders/benchmark_arrayloaders.py
+++ b/src/arrayloader_benchmarks/arrayloaders/benchmark_arrayloaders.py
@@ -43,7 +43,8 @@ def collate_fn(elems):
 @click.option("--batch_size", type=int, default=4096)
 @click.option("--n_samples", type=int, default=2_000_000)
 @click.option("--include_obs", type=bool, default=True)
-def benchmark(  # noqa: PLR0917
+@click.option("--n_shards", type=int, default=-1)
+def benchmark(  # noqa: PLR0917, PLR0913
     chunk_size: int = 256,
     preload_nchunks: int = 64,
     use_torch_loader: bool = False,  # noqa: FBT001, FBT002
@@ -51,11 +52,15 @@ def benchmark(  # noqa: PLR0917
     batch_size: int = 4096,
     n_samples: int = 2_000_000,
     include_obs: bool = True,  # noqa: FBT001, FBT002
+    n_shards: int = -1,
 ):
     benchmarking_collections = ln.Collection.using("laminlabs/arrayloader-benchmarks")
     collection = benchmarking_collections.get("LaJOdLd0xZ3v5ZBw0000")
+    if n_shards < 1:
+        n_shards = len(collection.ordered_artifacts.all())
     store_shards = [
-        artifact.cache(batch_size=48) for artifact in collection.ordered_artifacts.all()
+        artifact.cache(batch_size=48)
+        for artifact in collection.ordered_artifacts.all()[:n_shards]
     ]
 
     ds = ZarrSparseDataset(

--- a/src/arrayloader_benchmarks/mapped_collection/benchmark_mapped_collection.py
+++ b/src/arrayloader_benchmarks/mapped_collection/benchmark_mapped_collection.py
@@ -14,13 +14,20 @@ from arrayloader_benchmarks.utils import benchmark_loader
 @click.option("--num_workers", type=int, default=6)
 @click.option("--batch_size", type=int, default=4096)
 @click.option("--n_samples", type=int, default=2_000_000)
+@click.option("--n_shards", type=int, default=-1)
 def benchmark(
     num_workers: int = 6,
     batch_size: int = 4096,
     n_samples: int = 2_000_000,
+    n_shards: int = -1,
 ):
     benchmarking_collections = ln.Collection.using("laminlabs/arrayloader-benchmarks")
-    h5ad_shards = benchmarking_collections.get("eAgoduHMxuDs5Wem0000").cache()
+    collection = benchmarking_collections.get("eAgoduHMxuDs5Wem0000")
+    if n_shards < 1:
+        n_shards = len(collection.ordered_artifacts.all())
+    h5ad_shards = [
+        artifact.cache() for artifact in collection.ordered_artifacts.all()[:n_shards]
+    ]
 
     mapped_collection = MappedCollection(h5ad_shards)
     loader = DataLoader(


### PR DESCRIPTION
I've made the number of shards to use for the benchmarks configurable, as discussed in the [previous PR](https://github.com/laminlabs/arrayloader-benchmarks/pull/19).

I've added an argument `--n_shards` to specify the number of shards used. (Only the selected shards get cached by lamin). So, if you only wanna run on e.g. 2mio cells, only 2mio cells get downloaded