### PR TITLE
♻️ New `connect()` syntax

### DIFF
--- a/scripts/run_create_zarr_store_from_h5ads_for_tahoe100m.py
+++ b/scripts/run_create_zarr_store_from_h5ads_for_tahoe100m.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     ln.settings.sync_git_repo = "https://github.com/laminlabs/arrayloader-benchmarks"
     ln.track("zqsf9jOCh6pd", project="zjQ6EYzMXif4")
 
-    benchmarking_collections = ln.Collection.using("laminlabs/arrayloader-benchmarks")
+    benchmarking_collections = ln.Collection.connect("laminlabs/arrayloader-benchmarks")
 
     if GENE_SPACE == "FULL":
         h5ads_paths = (

--- a/scripts/run_loading_benchmark_on_collection.py
+++ b/scripts/run_loading_benchmark_on_collection.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 def get_datasets(
     *, collection_key: str, cache: bool = True, n_datasets: int = 1
 ) -> tuple[list[Path], int]:
-    benchmarking_collections = ln.Collection.using("laminlabs/arrayloader-benchmarks")
+    benchmarking_collections = ln.Collection.connect("laminlabs/arrayloader-benchmarks")
     collection = benchmarking_collections.get(key=collection_key)
     if n_datasets == -1:
         n_datasets = collection.artifacts.count()

--- a/scripts/shuffle_and_shard_tahoe100m_h5ads.py
+++ b/scripts/shuffle_and_shard_tahoe100m_h5ads.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         "9L9HZ55HqUL0aqaR0000",
         "vn5cUJCHbjpPPsZx0000",
     ]
-    benchmarking_artifacts = ln.Artifact.using("laminlabs/arrayloader-benchmarks")
+    benchmarking_artifacts = ln.Artifact.connect("laminlabs/arrayloader-benchmarks")
     file_paths = [benchmarking_artifacts.get(uid).cache() for uid in artifact_uids]
 
     # Create shuffled and sharded h5ad files --- FULL GENE SPACE


### PR DESCRIPTION
Just updating to the use the convention of lamindb 1.16 and there is no deprecated syntax in this benchmark.